### PR TITLE
Fix #167: Added README and improved styling for HTML-to-PDF example

### DIFF
--- a/itext-java-html-pdf/.classpath
+++ b/itext-java-html-pdf/.classpath
@@ -17,11 +17,3 @@
   <classpathentry kind="var" path="M2_REPO/com/itextpdf/svg/7.1.9/svg-7.1.9.jar"/>
   <classpathentry kind="var" path="M2_REPO/com/itextpdf/html2pdf/2.1.6/html2pdf-2.1.6.jar"/>
 </classpath>
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\src\main\java\com\hmkcode\App.java
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\.classpath
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\index.html
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\java.png
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\pom.xml
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\README.md
-C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\style.css

--- a/itext-java-html-pdf/.classpath
+++ b/itext-java-html-pdf/.classpath
@@ -17,3 +17,11 @@
   <classpathentry kind="var" path="M2_REPO/com/itextpdf/svg/7.1.9/svg-7.1.9.jar"/>
   <classpathentry kind="var" path="M2_REPO/com/itextpdf/html2pdf/2.1.6/html2pdf-2.1.6.jar"/>
 </classpath>
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\src\main\java\com\hmkcode\App.java
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\.classpath
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\index.html
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\java.png
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\pom.xml
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\README.md
+C:\Users\DHEERAJ KUMAR\Java\itext-java-html-pdf\style.css

--- a/itext-java-html-pdf/README.md
+++ b/itext-java-html-pdf/README.md
@@ -1,0 +1,27 @@
+# HTML to PDF with iText in Java
+
+This example demonstrates how to convert HTML content to PDF using the **iText 7** library in Java.
+
+## Features:
+
+- Converts a **hardcoded HTML string** into PDF (`string-to-pdf.pdf`)
+- Converts a **styled external HTML file** (`index.html + style.css`) into PDF (`index-to-pdf.pdf`)
+- Uses `HtmlConverter` from `iText pdfHTML`
+
+## Folder Contents
+
+| File : Purpose |
+
+| `App.java` | Java code for conversion |
+| `index.html` | HTML template for PDF |
+| `style.css` | Styling applied to the PDF |
+| `java.png` | Image used inside the HTML (optional) |
+
+## How to Run
+
+1. Ensure you have **Java 8+** and **iText 7 libraries** (`html2pdf` JARs)
+2. Compile and run the project:
+
+```bash
+javac -cp "itext7-core.jar" com/hmkcode/App.java
+java -cp ".;itext7-core.jar" com.hmkcode.App

--- a/itext-java-html-pdf/style.css
+++ b/itext-java-html-pdf/style.css
@@ -1,21 +1,70 @@
-h1 {
-  color:#ccc;
-}
-table tr td{
-	text-align:center;
-	border:1px solid gray;
-	padding:4px;
-}
-table tr th{
-	background-color:#84C7FD;
-	color:#fff;
-	width: 100px;
-}
-.itext{
-	color:#84C7FD;
-	font-weight:bold;
-}
-.description{
-	color:gray;
+/* ...existing code... */
+body {
+  background: #f7f9fb;
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
 }
 
+h1 {
+  color: #2d3e50;
+  text-align: center;
+  margin-top: 32px;
+  margin-bottom: 8px;
+  letter-spacing: 1px;
+}
+
+p {
+  text-align: center;
+  font-size: 1.1em;
+  margin-bottom: 24px;
+}
+
+img {
+  display: block;
+  margin: 0 auto 24px auto;
+  max-width: 120px;
+}
+
+table {
+  margin: 0 auto;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.07);
+  border-radius: 8px;
+  overflow: hidden;
+  min-width: 350px;
+}
+
+table tr th,
+table tr td {
+  text-align: left;
+  border: none;
+  padding: 12px 20px;
+}
+
+table tr th {
+  background-color: #84C7FD;
+  color: #fff;
+  width: 120px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+table tr:not(:last-child) td,
+table tr:not(:last-child) th {
+  border-bottom: 1px solid #e3e3e3;
+}
+
+.itext {
+  color: #2196f3;
+  font-weight: bold;
+  font-size: 1.15em;
+}
+
+.description {
+  color: #888;
+  font-style: italic;
+  margin-left: 8px;
+}
+/* ...existing code... */


### PR DESCRIPTION

This PR improves the `itext-java-html-pdf` example by:

- Adding a new `README.md` file with clear instructions and folder contents
-  Updating `style.css` for a cleaner, PDF-friendly design, centralizing the page content.

Purpose:
Helps address issue #167 ("Programas") by enhancing one of the sample folders to be more beginner-friendly and useful for HTML-to-PDF conversion with iText 7.

Closes #167
